### PR TITLE
Do not make jobs public

### DIFF
--- a/pipelines/_library.libsonnet
+++ b/pipelines/_library.libsonnet
@@ -77,7 +77,6 @@ local builder_config(name) =
     local dp = name + '-git/' + (if docker_path == null then '' else docker_path + '/');
     {
       name: 'build-' + name,
-      public: true,
       plan: [
         { get: name + '-git', trigger: true },
         {
@@ -94,7 +93,6 @@ local builder_config(name) =
   deploy_docker_systemd_job: function(name, host, key, service=null, passed=true)
     {
       name: 'deploy-' + name,
-      public: true,
       serial: true,
       plan: [
         { get: name + '-image', trigger: true, [if passed then 'passed']: ['build-' + name] },

--- a/pipelines/_simple_haskell.libsonnet
+++ b/pipelines/_simple_haskell.libsonnet
@@ -80,7 +80,6 @@ function(package, repo=null, subfolder=null, snapshot_filter_paths=null)
 
   local test_job(script=null) = {
     name: 'test-' + package,
-    public: true,
     plan: [
       { get: 'package-git', resource: package + '-cabal-git', trigger: true },
       build_test_task(false, script),
@@ -89,7 +88,6 @@ function(package, repo=null, subfolder=null, snapshot_filter_paths=null)
 
   local test_snapshot_job(script=null) = {
     name: 'test-snapshot-' + package,
-    public: true,
     plan: [
       { get: 'package-git', resource: package + '-git', trigger: true },
       { get: 'stackage-feed', trigger: true },
@@ -100,7 +98,6 @@ function(package, repo=null, subfolder=null, snapshot_filter_paths=null)
   local deploy_job(script=null) =
     {
       name: 'deploy-' + package,
-      public: true,
       plan: [
         { get: 'package-git', resource: package + '-cabal-git', trigger: true, passed: ['test-' + package] },
         if script == null then deploy_task else

--- a/pipelines/barrucadu.co.uk.jsonnet
+++ b/pipelines/barrucadu.co.uk.jsonnet
@@ -40,7 +40,6 @@ local run_buildpy_task(name) =
 local build_deploy_memo_job =
   {
     name: 'build-deploy-memo',
-    public: true,
     serial: true,
     plan: [
       { get: 'memo-git', trigger: true },
@@ -82,7 +81,6 @@ local build_deploy_memo_job =
 local build_deploy_www_job =
   {
     name: 'build-deploy-www',
-    public: true,
     serial: true,
     plan: [
       { get: 'cv-git', trigger: true },

--- a/pipelines/lainon.life.jsonnet
+++ b/pipelines/lainon.life.jsonnet
@@ -3,7 +3,6 @@ local library = import '_library.libsonnet';
 local build_deploy_frontend_job =
   {
     name: 'build-deploy-frontend',
-    public: true,
     serial: true,
     plan: [
       { get: 'lainonlife-git', trigger: true },

--- a/pipelines/lookwhattheshoggothdraggedin.com.jsonnet
+++ b/pipelines/lookwhattheshoggothdraggedin.com.jsonnet
@@ -3,7 +3,6 @@ local library = import '_library.libsonnet';
 local build_deploy_blog_job =
   {
     name: 'build-deploy-blog',
-    public: true,
     serial: true,
     plan: [
       { get: 'blog-git', trigger: true },

--- a/pipelines/uzbl.org.jsonnet
+++ b/pipelines/uzbl.org.jsonnet
@@ -3,7 +3,6 @@ local library = import '_library.libsonnet';
 local copy_git_to_rsync_job(name, repo) =
   {
     name: 'deploy-' + name,
-    public: true,
     serial: true,
     plan: [
       { get: name + '-git', trigger: true },


### PR DESCRIPTION
Since there is no longer a public frontend linking to these jobs,
there is no need for them to be easily accessible.  It's unlikely, but
I *could* end up leaking something sensitive in a build log, so better
to hide things by default.